### PR TITLE
allow the metric names to be changed with compile-time env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
   ```
 
 - A [builder-example](examples/builder-example/).
+- The metric names can be changed by setting some environmental variables at compile time. It is best to set these in the `config.toml` (note this is not the same file as `Cargo.toml`):
+  ```toml
+  [env]
+  AXUM_HTTP_REQUESTS_TOTAL = "my_app_requests_total"
+  AXUM_HTTP_REQUESTS_DURATION_SECONDS = "my_app_requests_duration_seconds"
+  AXUM_HTTP_REQUESTS_PENDING = "my_app_requests_pending"
+  ```
 
 ## [0.2.0] - 2022-10-25
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ By default three HTTP metrics are tracked
 
 Note that in the future request size metric is also planned to be implemented.
 
+### Renaming Metrics
+ 
+These metrics can be renamed by specifying environmental variables at compile time:
+- `AXUM_HTTP_REQUESTS_TOTAL`
+- `AXUM_HTTP_REQUESTS_DURATION_SECONDS`
+- `AXUM_HTTP_REQUESTS_PENDING`
+
+Thse environmental variables can be set in your `.cargo/config.toml` since Cargo 1.56:
+```toml
+[env]
+AXUM_HTTP_REQUESTS_TOTAL = "my_app_requests_total"
+AXUM_HTTP_REQUESTS_DURATION_SECONDS = "my_app_requests_duration_seconds"
+AXUM_HTTP_REQUESTS_PENDING = "my_app_requests_pending"
+```
+
 ### Compatibility
 
 | Axum Version | Crate Version |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,21 @@
 //!
 //! Note that in the future request size metric is also planned to be implemented.
 //!
+//! ### Renaming Metrics
+//!  
+//! These metrics can be renamed by specifying environmental variables at compile time:
+//! - `AXUM_HTTP_REQUESTS_TOTAL`
+//! - `AXUM_HTTP_REQUESTS_DURATION_SECONDS`
+//! - `AXUM_HTTP_REQUESTS_PENDING`
+//!
+//! Thse environmental variables can be set in your `.cargo/config.toml` since Cargo 1.56:
+//! ```toml
+//! [env]
+//! AXUM_HTTP_REQUESTS_TOTAL = "my_app_requests_total"
+//! AXUM_HTTP_REQUESTS_DURATION_SECONDS = "my_app_requests_duration_seconds"
+//! AXUM_HTTP_REQUESTS_PENDING = "my_app_requests_pending"
+//! ```
+//!
 //! ## Usage
 //!
 //! For more elaborate use-cases, see the builder-example that leverages [`PrometheusMetricLayerBuilder`].
@@ -78,13 +93,23 @@
 #![allow(clippy::module_name_repetitions, clippy::unreadable_literal)]
 
 /// Identifies the gauge used for the requests pending metric.
-pub const AXUM_HTTP_REQUESTS_PENDING: &str = "axum_http_requests_pending";
+pub const AXUM_HTTP_REQUESTS_PENDING: &str = match option_env!("AXUM_HTTP_REQUESTS_PENDING") {
+    Some(n) => n,
+    None => "axum_http_requests_pending",
+};
 
 /// Identifies the histogram/summary used for request latency.
-pub const AXUM_HTTP_REQUESTS_DURATION_SECONDS: &str = "axum_http_requests_duration_seconds";
+pub const AXUM_HTTP_REQUESTS_DURATION_SECONDS: &str =
+    match option_env!("AXUM_HTTP_REQUESTS_DURATION_SECONDS") {
+        Some(n) => n,
+        None => "axum_http_requests_duration_seconds",
+    };
 
 /// Identifies the counter used for requests total.
-pub const AXUM_HTTP_REQUESTS_TOTAL: &str = "axum_http_requests_total";
+pub const AXUM_HTTP_REQUESTS_TOTAL: &str = match option_env!("AXUM_HTTP_REQUESTS_TOTAL") {
+    Some(n) => n,
+    None => "axum_http_requests_total",
+};
 
 use std::collections::HashMap;
 use std::time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,20 +92,24 @@
 
 #![allow(clippy::module_name_repetitions, clippy::unreadable_literal)]
 
-/// Identifies the gauge used for the requests pending metric.
+/// Identifies the gauge used for the requests pending metric. Defaults to
+/// `axum_http_requests_pending`, but can be changed by setting the `AXUM_HTTP_REQUESTS_PENDING`
+/// env at compile time.
 pub const AXUM_HTTP_REQUESTS_PENDING: &str = match option_env!("AXUM_HTTP_REQUESTS_PENDING") {
     Some(n) => n,
     None => "axum_http_requests_pending",
 };
 
-/// Identifies the histogram/summary used for request latency.
+/// Identifies the histogram/summary used for request latency. Defaults to `axum_http_requests_duration_seconds`,
+/// but can be changed by setting the `AXUM_HTTP_REQUESTS_DURATION_SECONDS` env at compile time.
 pub const AXUM_HTTP_REQUESTS_DURATION_SECONDS: &str =
     match option_env!("AXUM_HTTP_REQUESTS_DURATION_SECONDS") {
         Some(n) => n,
         None => "axum_http_requests_duration_seconds",
     };
 
-/// Identifies the counter used for requests total.
+/// Identifies the counter used for requests total. Defaults to `axum_http_requests_total`,
+/// but can be changed by setting the `AXUM_HTTP_REQUESTS_TOTAL` env at compile time.
 pub const AXUM_HTTP_REQUESTS_TOTAL: &str = match option_env!("AXUM_HTTP_REQUESTS_TOTAL") {
     Some(n) => n,
     None => "axum_http_requests_total",


### PR DESCRIPTION
To match local conventions I needed to adjust the metric names and I'm not able to modify the scrape config. Thus, I made this patch which allows these `AXUM_HTTP_*` constants to be changed via envs.

It is common for applications metrics to have an application-specific prefix.  Metrics can be renamed at scrape time of course, but in some environments an application is expected to merely expose metrics on a given port and no other configuration is allowed.

This commit allows the metric names to be changed at compile time by setting the following environment variables:
- `AXUM_HTTP_REQUESTS_TOTAL`
- `AXUM_HTTP_REQUESTS_DURATION_SECONDS`
- `AXUM_HTTP_REQUESTS_PENDING`

In the absence of these environment variables, the metric names are unchanged.

This commit also documents the usage of these envs and suggests setting them in .cargo/config.toml