### PR TITLE
Add the `with_prefix` function to the builder. #10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tower-http = "0.3.4"
 bytes = "1.2.1"
 futures-core = "0.3.24"
 matchit = "0.6"
+once_cell = "1.17.0"
 
 [dev-dependencies]
 hyper = "0.14.20"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use metrics_exporter_prometheus::PrometheusHandle;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -53,6 +53,7 @@ pub enum EndpointLabel {
 pub struct PrometheusMetricLayerBuilder<'a, S: MetricBuilderState> {
     pub(crate) traffic: Traffic<'a>,
     pub(crate) metric_handle: Option<PrometheusHandle>,
+    pub(crate) metric_prefix: Option<String>,
     pub(crate) _marker: PhantomData<S>,
 }
 
@@ -139,14 +140,8 @@ where
         self
     }
 
-    /// Use a prefix for the metrics instead of `axum`. This will use the following metric names:
-    ///  - `{prefix}_http_requests_total`
-    ///  - `{prefix}_http_requests_pending`
-    ///  - `{prefix}_http_requests_duration_seconds`
-    ///
-    /// Note that this will take precedence over environment variables.
     pub fn with_prefix(mut self, prefix: String) -> Self {
-        self.traffic.metric_prefix = Some(prefix);
+        self.metric_prefix = Some(prefix);
         self
     }
 }
@@ -158,6 +153,7 @@ impl<'a> PrometheusMetricLayerBuilder<'a, LayerOnly> {
             _marker: PhantomData,
             traffic: Traffic::new(),
             metric_handle: None,
+            metric_prefix: None,
         }
     }
 
@@ -222,6 +218,7 @@ impl<'a> PrometheusMetricLayerBuilder<'a, Paired> {
             _marker: PhantomData,
             traffic: layer_only.traffic,
             metric_handle: layer_only.metric_handle,
+            metric_prefix: None,
         }
     }
     /// Finalize the builder and get out the [`PrometheusMetricLayer`] and the

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -147,8 +147,8 @@ where
     ///  - `{prefix}_http_requests_duration_seconds`
     ///
     /// Note that this will take precedence over environment variables.
-    pub fn with_prefix(mut self, prefix: String) -> Self {
-        self.metric_prefix = Some(prefix);
+    pub fn with_prefix(mut self, prefix: impl Into<Cow<'a, str>>) -> Self {
+        self.metric_prefix = Some(prefix.into().into_owned());
         self
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -143,6 +143,8 @@ where
     ///  - `{prefix}_http_requests_total`
     ///  - `{prefix}_http_requests_pending`
     ///  - `{prefix}_http_requests_duration_seconds`
+    ///
+    /// Note that this will take precedence over environment variables.
     pub fn with_prefix(mut self, prefix: String) -> Self {
         self.traffic.metric_prefix = Some(prefix);
         self

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -140,6 +140,13 @@ where
         self
     }
 
+    /// Use a prefix for the metrics instead of `axum`. This will use the following
+    /// metric names:
+    ///  - `{prefix}_http_requests_total`
+    ///  - `{prefix}_http_requests_pending`
+    ///  - `{prefix}_http_requests_duration_seconds`
+    ///
+    /// Note that this will take precedence over environment variables.
     pub fn with_prefix(mut self, prefix: String) -> Self {
         self.metric_prefix = Some(prefix);
         self

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -138,6 +138,15 @@ where
         self.traffic.with_endpoint_label_type(endpoint_label);
         self
     }
+
+    /// Use a prefix for the metrics instead of `axum`. This will use the following metric names:
+    ///  - `{prefix}_http_requests_total`
+    ///  - `{prefix}_http_requests_pending`
+    ///  - `{prefix}_http_requests_duration_seconds`
+    pub fn with_prefix(mut self, prefix: String) -> Self {
+        self.traffic.metric_prefix = Some(prefix);
+        self
+    }
 }
 
 impl<'a> PrometheusMetricLayerBuilder<'a, LayerOnly> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,14 +272,12 @@ impl<'a, FailureClass> Callbacks<FailureClass> for Traffic<'a> {
 
         let requests_total = PREFIXED_HTTP_REQUESTS_TOTAL
             .get()
-            .and_then(|s| Some(s.as_str()))
-            .unwrap_or(AXUM_HTTP_REQUESTS_TOTAL);
+            .map_or(AXUM_HTTP_REQUESTS_TOTAL, |s| s.as_str());
         increment_counter!(requests_total, &labels);
 
         let requests_pending = PREFIXED_HTTP_REQUESTS_PENDING
             .get()
-            .and_then(|s| Some(s.as_str()))
-            .unwrap_or(AXUM_HTTP_REQUESTS_PENDING);
+            .map_or(AXUM_HTTP_REQUESTS_PENDING, |s| s.as_str());
         increment_gauge!(requests_pending, 1.0, &labels);
 
         Some(MetricsData {
@@ -300,8 +298,7 @@ impl<'a, FailureClass> Callbacks<FailureClass> for Traffic<'a> {
 
             let requests_pending = PREFIXED_HTTP_REQUESTS_PENDING
                 .get()
-                .and_then(|s| Some(s.as_str()))
-                .unwrap_or(AXUM_HTTP_REQUESTS_PENDING);
+                .map_or(AXUM_HTTP_REQUESTS_PENDING, |s| s.as_str());
             decrement_gauge!(
                 requests_pending,
                 1.0,
@@ -313,9 +310,7 @@ impl<'a, FailureClass> Callbacks<FailureClass> for Traffic<'a> {
 
             let requests_duration = PREFIXED_HTTP_REQUESTS_DURATION_SECONDS
                 .get()
-                .and_then(|s| Some(s.as_str()))
-                .unwrap_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS);
-
+                .map_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS, |s| s.as_str());
             histogram!(
                 requests_duration,
                 duration_seconds,


### PR DESCRIPTION
This adds the `with_prefix` function to the `PrometheusMetricLayerBuilder` that will replace the `axum` prefix of all of the metrics. Calling this will override the env vars, if they are set.

A couple of notes on this PR:
- The `with_prefix` function takes a `String` and not an `&str` as the builder (and subsequently `Traffic`) should have ownership of this prefix.
- The `prepare` and `on_response` functions branch on this prefix `Option`, resulting in a slight duplication of the metrics macros, but also ensures there is no unnecessary prefix allocation if not using the prefix.