### PR TITLE
always export the requests duration as histogram

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -140,18 +140,6 @@ where
         self.traffic.with_endpoint_label_type(endpoint_label);
         self
     }
-
-    /// Use a prefix for the metrics instead of `axum`. This will use the following
-    /// metric names:
-    ///  - `{prefix}_http_requests_total`
-    ///  - `{prefix}_http_requests_pending`
-    ///  - `{prefix}_http_requests_duration_seconds`
-    ///
-    /// Note that this will take precedence over environment variables.
-    pub fn with_prefix(mut self, prefix: impl Into<Cow<'a, str>>) -> Self {
-        self.metric_prefix = Some(prefix.into().into_owned());
-        self
-    }
 }
 
 impl<'a> PrometheusMetricLayerBuilder<'a, LayerOnly> {
@@ -212,6 +200,18 @@ impl<'a> PrometheusMetricLayerBuilder<'a, LayerOnly> {
     ) -> PrometheusMetricLayerBuilder<'a, Paired> {
         self.metric_handle = Some(f());
         PrometheusMetricLayerBuilder::<'_, Paired>::from_layer_only(self)
+    }
+
+    /// Use a prefix for the metrics instead of `axum`. This will use the following
+    /// metric names:
+    ///  - `{prefix}_http_requests_total`
+    ///  - `{prefix}_http_requests_pending`
+    ///  - `{prefix}_http_requests_duration_seconds`
+    ///
+    /// Note that this will take precedence over environment variables.
+    pub fn with_prefix(mut self, prefix: impl Into<Cow<'a, str>>) -> Self {
+        self.metric_prefix = Some(prefix.into().into_owned());
+        self
     }
 
     /// Finalize the builder and get the [`PrometheusMetricLayer`] out of it.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -226,7 +226,7 @@ impl<'a> PrometheusMetricLayerBuilder<'a, Paired> {
             _marker: PhantomData,
             traffic: layer_only.traffic,
             metric_handle: layer_only.metric_handle,
-            metric_prefix: None,
+            metric_prefix: layer_only.metric_prefix,
         }
     }
     /// Finalize the builder and get out the [`PrometheusMetricLayer`] and the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,12 @@ impl<'a> PrometheusMetricLayer<'a> {
     pub(crate) fn make_default_handle() -> PrometheusHandle {
         PrometheusBuilder::new()
             .set_buckets_for_metric(
-                Matcher::Full(AXUM_HTTP_REQUESTS_DURATION_SECONDS.to_string()),
+                Matcher::Full(
+                    PREFIXED_HTTP_REQUESTS_DURATION_SECONDS
+                        .get()
+                        .map_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS, |s| s.as_str())
+                        .to_string(),
+                ),
                 SECONDS_DURATION_BUCKETS,
             )
             .unwrap()


### PR DESCRIPTION
handle the case where the user has set a custom prefix.

Fixes https://github.com/Ptrskay3/axum-prometheus/issues/24

This fix is not ideal.
The user has to call `with_prefix` before calling `with_default_metrics`.