### PR TITLE
deps: update metrics to v0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ axum = "0.7.1"
 futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
-metrics = "0.21.0"
-metrics-exporter-prometheus = { version =  "0.12.0", optional =  true }
+metrics = "0.22.0"
+metrics-exporter-prometheus = { version =  "0.13.0", optional =  true }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION


Update `metrics` and use the new APIs:
- `{increment,decrement}_gauge!()` → `gauge!().{increment,decrement}`
- `increment_counter!()` → `counter!().increment()`
- `histogram!()` → `histogram!().record()`