### PR TITLE
Update version of metrics to fix integration with other tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ axum = "0.7.1"
 futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
-metrics = "0.21.0"
-metrics-exporter-prometheus = { version =  "0.12.0", optional =  true }
+metrics = "0.22.0"
+metrics-exporter-prometheus = { version =  "0.13.0", optional =  true }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
The current version of metrics (0.21.0) uses an older version of macros that point to different global allocators than the current latest version (0.22.0) causing metrics to not be reported by other tools integrating with the `metrics` facade.

Since https://github.com/metrics-rs/metrics/pull/414, the `metrics` project now can have different registries, and such, the macros (eg: `counter!`) have been refactored.

As this is a pre-1.0 project, including axum-prometheus into a project with `metrics:0.22.0` register 2 different versions of the metrics crate. So metrics reported by `axum-prometheus` will be registered on the `metrics:0.21.0` global collector, while the project's metrics will use the `metrics:0.22.0` global collector.

While the current suggested method of exporting the `let (_, handle)` as a route will work, as it's pointing to the `metrics:0.21.0` collectors, other integrations such as the push-based background task will miss out the layer metrics.

By upgrading this project to `metrics:0.22.0` we can ensure it's reporting to the same global collector, and thus integrated with other `metrics`-based tools.

This commit bumps the metrics version to 0.22.0 as well as fix the macro invocations introduced on the new version.

---

Thanks for the project :)