### PR TITLE
metrics-exporter-prometheus: push-gateway feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
 metrics = "0.22.0"
-metrics-exporter-prometheus = { version =  "0.13.0", optional =  true }
+metrics-exporter-prometheus = { version =  "0.13.0", optional =  true, default-features = false, features = ["http-listener"] }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
@@ -33,4 +33,5 @@ http-body-util = "0.1.0"
 [features]
 default = ["prometheus"]
 prometheus = ["metrics-exporter-prometheus"]
+push-gateway = ["metrics-exporter-prometheus/push-gateway"]
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ axum_http_requests_duration_seconds_sum{method="GET",status="200",endpoint="/met
 axum_http_requests_duration_seconds_count{method="GET",status="200",endpoint="/metrics"} 4
 ```
 
+Let's note that since `metrics-exporter-prometheus = "0.13"` that crate [introduced](https://github.com/metrics-rs/metrics/commit/d817f5c6f4909eeafbd9ff9ceadbf29302169bfa) the `push-gateway` default feature, that
+requires openssl support. The `axum_prometheus` crate __does not__ rely on, nor enable this feature by default — if you need it, 
+you may enable it through the `"push-gateway"` feature in `axum_prometheus`.
+
 ## Using a different exporter than Prometheus
 
 This crate may be used with other exporters than Prometheus. First, disable the default features:


### PR DESCRIPTION
Fixes #42.

The `"push-gateway"` feature is turned off by default. Also added an extra note in the README about it.