### PR TITLE
Change default initialization of PrometheusHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `MakeDefaultHandle::make_default_handle` now takes `self` as argument. This allows custom implementor structs to hold non-static data. [\#49]
+- Change the default initialization of `PrometheusHandle` to prevent unbounded memory growth of histograms. [\#52]
+- Bump `metrics` to `0.23`, `metrics-exporter-prometheus` to `0.15`. [\#52]
+- Document MSRV as 1.70 currently. [\#52]
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.2.1"
 futures-core = "0.3.24"
 matchit = "0.7"
 once_cell = "1.17.0"
+metrics-util = "0.17.0"
 
 [dev-dependencies]
 hyper = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ axum = "0.7.1"
 futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
-metrics = "0.22.0"
-metrics-exporter-prometheus = { version =  "0.14.0", optional =  true, default-features = false, features = ["http-listener"] }
+metrics = "0.23.0"
+metrics-exporter-prometheus = { version =  "0.15.0", optional =  true, default-features = false, features = ["http-listener"] }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/Ptrskay3/axum-prometheus"
 
 [dependencies]
 axum = "0.7.1"
-futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
 metrics = "0.23.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ bytes = "1.2.1"
 futures-core = "0.3.24"
 matchit = "0.7"
 once_cell = "1.17.0"
-metrics-util = "0.17.0"
 
 [dev-dependencies]
 hyper = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ AXUM_HTTP_RESPONSE_BODY_SIZE = "my_app_response_body_size"
 | `0.6`        | `0.2`, `0.3`, `0.4`  |
 | `0.7`        | `0.5`, `0.6`         |
 
+#### MSRV
+
+This crate's current MSRV is 1.70.
+
 ## Usage
 
 For more elaborate use-cases, see the [`builder example`](examples/builder-example/).

--- a/examples/exporter-statsd-example/Cargo.toml
+++ b/examples/exporter-statsd-example/Cargo.toml
@@ -9,6 +9,6 @@ axum = "0.7.1"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-metrics-exporter-statsd = "0.7.0"
+metrics-exporter-statsd = "0.8.0"
 axum-prometheus = { path = "../../", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,9 +738,15 @@ pub struct Handle(pub PrometheusHandle);
 #[cfg(feature = "prometheus")]
 impl Default for Handle {
     fn default() -> Self {
+        // TODO: in push-gateway mode we need to tokio::spawn the exporter future.
+        // Also, we need a way to configure the push gateway exporter (PrometheusBuilder::with_push_gateway).
+
         let (recorder, _) = PrometheusBuilder::new()
             .upkeep_timeout(Duration::from_secs(5))
-            .idle_timeout(MetricKindMask::HISTOGRAM, Some(Duration::from_secs(300)))
+            .idle_timeout(
+                MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM,
+                Some(Duration::from_secs(300)),
+            )
             .set_buckets_for_metric(
                 Matcher::Full(
                     PREFIXED_HTTP_REQUESTS_DURATION_SECONDS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 mod builder;
@@ -216,6 +217,7 @@ use lifecycle::layer::LifeCycleLayer;
 use lifecycle::OnBodyChunk;
 use lifecycle::{service::LifeCycle, Callbacks};
 use metrics::{counter, gauge, histogram};
+use metrics_util::MetricKindMask;
 use once_cell::sync::OnceCell;
 use tower::Layer;
 use tower_http::classify::{ClassifiedResponse, SharedClassifier, StatusInRangeAsFailures};
@@ -736,21 +738,24 @@ pub struct Handle(pub PrometheusHandle);
 #[cfg(feature = "prometheus")]
 impl Default for Handle {
     fn default() -> Self {
-        Self(
-            PrometheusBuilder::new()
-                .set_buckets_for_metric(
-                    Matcher::Full(
-                        PREFIXED_HTTP_REQUESTS_DURATION_SECONDS
-                            .get()
-                            .map_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS, |s| s.as_str())
-                            .to_string(),
-                    ),
-                    utils::SECONDS_DURATION_BUCKETS,
-                )
-                .unwrap()
-                .install_recorder()
-                .unwrap(),
-        )
+        let (recorder, _) = PrometheusBuilder::new()
+            .upkeep_timeout(Duration::from_secs(5))
+            .idle_timeout(MetricKindMask::HISTOGRAM, Some(Duration::from_secs(300)))
+            .set_buckets_for_metric(
+                Matcher::Full(
+                    PREFIXED_HTTP_REQUESTS_DURATION_SECONDS
+                        .get()
+                        .map_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS, |s| s.as_str())
+                        .to_string(),
+                ),
+                utils::SECONDS_DURATION_BUCKETS,
+            )
+            .unwrap()
+            .build()
+            .expect("Failed to build metrics recorder");
+        let handle = recorder.handle();
+        metrics::set_global_recorder(recorder).expect("Failed to set global recorder");
+        Self(handle)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,6 @@ use lifecycle::layer::LifeCycleLayer;
 use lifecycle::OnBodyChunk;
 use lifecycle::{service::LifeCycle, Callbacks};
 use metrics::{counter, gauge, histogram};
-use metrics_util::MetricKindMask;
 use once_cell::sync::OnceCell;
 use tower::Layer;
 use tower_http::classify::{ClassifiedResponse, SharedClassifier, StatusInRangeAsFailures};
@@ -738,15 +737,9 @@ pub struct Handle(pub PrometheusHandle);
 #[cfg(feature = "prometheus")]
 impl Default for Handle {
     fn default() -> Self {
-        // TODO: in push-gateway mode we need to tokio::spawn the exporter future.
-        // Also, we need a way to configure the push gateway exporter (PrometheusBuilder::with_push_gateway).
-
+        // TODO: Handle the push gateway feature somehow.
         let (recorder, _) = PrometheusBuilder::new()
             .upkeep_timeout(Duration::from_secs(5))
-            .idle_timeout(
-                MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM,
-                Some(Duration::from_secs(300)),
-            )
             .set_buckets_for_metric(
                 Matcher::Full(
                     PREFIXED_HTTP_REQUESTS_DURATION_SECONDS


### PR DESCRIPTION
Addresses #51, based on https://github.com/metrics-rs/metrics/issues/467.

This change prevents unbounded memory growth of metrics histograms by swapping `PrometheusHandle::install_recorder` to `PrometheusHandle::build`, that allows the upkeep task to be created, and the data is properly drained.

Other changes:
- Bump `metrics` to `0.23`, `metrics-exporter-prometheus` to `0.15`.
- Document current MSRV

TODO:
- [ ] ~Figure out what to do when `push-gateway` is enabled.~