### PR TITLE
bump metrics to 0.23, and attendant metrics-exporter-prometheus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ axum = "0.7.1"
 futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
-metrics = "0.22.0"
-metrics-exporter-prometheus = { version =  "0.14.0", optional =  true, default-features = false, features = ["http-listener"] }
+metrics = "0.23.0"
+metrics-exporter-prometheus = { version =  "0.15.0", optional =  true, default-features = false, features = ["http-listener"] }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
i tested locally and things are passing