### PR TITLE
Update dependencies & remove unused futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ repository = "https://github.com/Ptrskay3/axum-prometheus"
 
 [dependencies]
 axum = "0.7.1"
-futures = "0.3.23"
 http = "1.0.0"
 http-body = "1.0.0"
-metrics = "0.22.0"
-metrics-exporter-prometheus = { version =  "0.14.0", optional =  true, default-features = false, features = ["http-listener"] }
+metrics = "0.23.0"
+metrics-exporter-prometheus = { version =  "0.15.0", optional =  true, default-features = false, features = ["http-listener"] }
 pin-project = "1.0.12"
 tower = "0.4.13"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
`metrics`:  https://github.com/metrics-rs/metrics/blob/main/metrics/CHANGELOG.md#0230---2024-05-27
`metrics-exporter-prometheus`: https://github.com/metrics-rs/metrics/blob/main/metrics-exporter-prometheus/CHANGELOG.md#0151---2024-06-24

Didn't dare to update `matchit`, there seem to be some breaking changes between `0.7` and `0.8`