### PR TITLE
Prevent the automatic binding of the 9000 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Compatibility with `axum = "0.8"`. This also updates `matchit` to `0.8`, changing how group pattern are described:
   for example, `with_group_patterns_as("/foo", &["/foo/:bar"])` needs to be changed to `with_group_patterns_as("/foo", &["/foo/{bar}"])`.
   The metrics values are also impacted: for example, the value `"/foo/:bar"` is now `"/foo/{bar}"`. [\#69]
+- Disable the default features in `metrics-exporter-prometheus` to skip the binding of port 9000, and the upkeep task is manually spawned. [\#75]
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ axum = "0.8.0-alpha.1"
 http = "1.0.0"
 http-body = "1.0.0"
 metrics = "0.24.0"
-metrics-exporter-prometheus = { version = "0.16.0", optional = true, default-features = false, features = [
-    "http-listener",
-] }
+metrics-exporter-prometheus = { version = "0.16.0", optional = true, default-features = false }
 pin-project = "1.0.12"
 tower = "0.5.1"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
@@ -28,7 +26,7 @@ once_cell = "1.17.0"
 
 [dev-dependencies]
 hyper = "1.0.1"
-insta = { version = "1.31.0", features = ["yaml", "filters"] }
+insta = { version = "1.41.1", features = ["yaml", "filters"] }
 http-body-util = "0.1.0"
 
 [features]


### PR DESCRIPTION
Aims to fix #66 

Disable the default features in `metrics_exporter_prometheus` to prevent binding to port 9000 when using the upkeep task; spawn the future manually in the Default implementation.

 This is not a particularly good way to solve the issue, but there is no better option currently. Eventually this should be fixed in the `metrics_exporter_prometheus` crate.