### PR TITLE
Bump metrics-exporter-prometheus version to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ axum = "0.8.0"
 http = "1.2.0"
 http-body = "1.0.0"
 metrics = "0.24.1"
-metrics-exporter-prometheus = { version = "0.16.0", optional = true, default-features = false }
+metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false }
 pin-project-lite = "0.2.15"
 tower = "0.5.1"
 tokio = { version = "1.42.0", features = ["rt-multi-thread", "macros"] }

--- a/examples/base-metric-layer-example/src/main.rs
+++ b/examples/base-metric-layer-example/src/main.rs
@@ -21,6 +21,7 @@ async fn main() {
             Duration::from_secs(10),
             None,
             None,
+            true,
         )
         .expect("push gateway endpoint should be valid")
         .install()

--- a/examples/endpoint-type-example/src/main.rs
+++ b/examples/endpoint-type-example/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
 
     let (prometheus_layer, metric_handle) = PrometheusMetricLayerBuilder::new()
         .with_endpoint_label_type(EndpointLabel::MatchedPathWithFallbackFn(|path| {
-            format!("{}_changed", path)
+            format!("{path}_changed")
         }))
         .with_default_metrics()
         .build_pair();


### PR DESCRIPTION
This pull request updates the dependency versions in the `Cargo.toml` file to simplify versioning.